### PR TITLE
Feature/api television

### DIFF
--- a/answers/en.json
+++ b/answers/en.json
@@ -518,5 +518,125 @@
                 "text": "Music stopped sir !"
             }
         ]
+    },
+
+    {
+        "label": "tell-television-set-channel",
+        "needAnswer": false,
+        "language": "en",
+        "responses": [
+            {
+                "uuid": "55be3be2-2611-44a2-b54d-3d25ce9237bb",
+                "text": "The channel was changed !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-switch-state",
+        "needAnswer": false,
+        "language": "en",
+        "responses": [
+            {
+                "uuid": "55af847b-544c-4197-9da9-bc3712fe2663",
+                "text": "The tv state was changed !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-paused",
+        "needAnswer": false,
+        "language": "en",
+        "responses": [
+            {
+                "uuid": "82edebcb-6a6c-42a2-a016-449fe9650905",
+                "text": "The video is paused !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-played",
+        "needAnswer": false,
+        "language": "en",
+        "responses": [
+            {
+                "uuid": "99d94f81-86f9-4530-8ce7-e9c2e8cead61",
+                "text": "The video is started !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-stopped",
+        "needAnswer": false,
+        "language": "en",
+        "responses": [
+            {
+                "uuid": "d97834d5-75c5-4fbd-b630-cf0c756d6140",
+                "text": "The video is stopped !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-rewind",
+        "needAnswer": false,
+        "language": "en",
+        "responses": [
+            {
+                "uuid": "824b0310-0fb1-4f63-a4c3-9e9735e80718",
+                "text": "The video is rewinding !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-fast-forward",
+        "needAnswer": false,
+        "language": "en",
+        "responses": [
+            {
+                "uuid": "1ccae0a0-da3f-4d52-ab2a-42998dfcb4a7",
+                "text": "The video moves forward !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-change-chaine",
+        "needAnswer": false,
+        "language": "en",
+        "responses": [
+            {
+                "uuid": "f26973c9-d4c9-4e34-9285-11436232c658",
+                "text": "The tv channel has been changed !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-change-volume",
+        "needAnswer": false,
+        "language": "en",
+        "responses": [
+            {
+                "uuid": "7fecae22-f72a-4c3d-8007-849ecad03d66",
+                "text": "The volume of the TV has been changed !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-mute",
+        "needAnswer": false,
+        "language": "en",
+        "responses": [
+            {
+                "uuid": "47516586-b64a-4464-a223-33ae7bc4f17f",
+                "text": "The volume of the TV has been muted !"
+            }
+        ]
     }
 ]

--- a/answers/fr.json
+++ b/answers/fr.json
@@ -598,5 +598,125 @@
                 "text": "J'ai coupé la musique !"
             }
         ]
+    },
+
+    {
+        "label": "tell-television-set-channel",
+        "needAnswer": false,
+        "language": "fr",
+        "responses": [
+            {
+                "uuid": "c04af245-5885-44fb-b616-e9796c0ff48e",
+                "text": "La chaine à été changé !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-switch-state",
+        "needAnswer": false,
+        "language": "fr",
+        "responses": [
+            {
+                "uuid": "eece48c3-f237-40ad-a99d-442734f591d7",
+                "text": "L'état de la télé à été changé !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-paused",
+        "needAnswer": false,
+        "language": "fr",
+        "responses": [
+            {
+                "uuid": "286b4279-f456-46b6-9b19-588f656b37aa",
+                "text": "La video est sur pause !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-played",
+        "needAnswer": false,
+        "language": "fr",
+        "responses": [
+            {
+                "uuid": "4d60cf47-e477-4529-aebb-81a72fe9e61c",
+                "text": "La video est lancé !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-stopped",
+        "needAnswer": false,
+        "language": "fr",
+        "responses": [
+            {
+                "uuid": "ee8984dc-d392-4a0d-9907-e4b4a6166505",
+                "text": "La video est stopé !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-rewind",
+        "needAnswer": false,
+        "language": "fr",
+        "responses": [
+            {
+                "uuid": "1a771b1e-2fea-4406-8e6f-616fc850953f",
+                "text": "La video rembobine !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-fast-forward",
+        "needAnswer": false,
+        "language": "fr",
+        "responses": [
+            {
+                "uuid": "6845cd1a-2ef0-4257-853a-ca72202da384",
+                "text": "La video accélère !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-change-chaine",
+        "needAnswer": false,
+        "language": "fr",
+        "responses": [
+            {
+                "uuid": "76fe8274-d190-4d82-bc04-034aa7300f83",
+                "text": "La chaine de la télé à été changé !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-change-volume",
+        "needAnswer": false,
+        "language": "fr",
+        "responses": [
+            {
+                "uuid": "ea886405-5929-4c1c-b9c8-82dcb1d91989",
+                "text": "Le volume de la télé à été modifié !"
+            }
+        ]
+    },
+
+    {
+        "label": "television-mute",
+        "needAnswer": false,
+        "language": "fr",
+        "responses": [
+            {
+                "uuid": "842c46fd-52d4-4232-b9be-e25c22d10dfd",
+                "text": "Le volume de la télé à coupé !"
+            }
+        ]
     }
 ]

--- a/sentences/en.json
+++ b/sentences/en.json
@@ -1003,4 +1003,88 @@
 	"label": "play-music",
 	"service": 0,
 	"language": "en"
+}, {
+  "uuid": "0d7e2320-b4ce-11e8-96f8-529269fb1459",
+  "text": "Put channel xx",
+  "label": "television-set-channel",
+  "service": "television",
+  "language": "en"
+}, {
+  "uuid": "0d7e2690-b4ce-11e8-96f8-529269fb1459",
+  "text": "Switch tv on",
+  "label": "television-switch-state",
+  "service": "television",
+  "language": "en"
+}, {
+  "uuid": "0d7e28a2-b4ce-11e8-96f8-529269fb1459",
+  "text": "Switch tv off",
+  "label": "television-switch-state",
+  "service": "television",
+  "language": "en"
+}, {
+  "uuid": "0d7e2c94-b4ce-11e8-96f8-529269fb1459",
+  "text": "Put television on pause",
+  "label": "television-pause",
+  "service": "television",
+  "language": "en"
+}, {
+  "uuid": "0d7e2e7e-b4ce-11e8-96f8-529269fb1459",
+  "text": "Stop the video",
+  "label": "television-stop",
+  "service": "television",
+  "language": "en"
+}, {
+  "uuid": "0d7e3086-b4ce-11e8-96f8-529269fb1459",
+  "text": "Put television on play",
+  "label": "television-play",
+  "service": 0,
+  "language": "en"
+}, {
+  "uuid": "0d7e3360-b4ce-11e8-96f8-529269fb1459",
+  "text": "Rewind the video",
+  "label": "television-rewind",
+  "service": "television",
+  "language": "en"
+}, {
+  "uuid": "0d7e34be-b4ce-11e8-96f8-529269fb1459",
+  "text": "Forward the video",
+  "label": "television-fast-forward",
+  "service": "television",
+  "language": "en"
+}, {
+  "uuid": "0d7e35ea-b4ce-11e8-96f8-529269fb1459",
+  "text": "Next channel",
+  "label": "television-program-plus",
+  "service": "television",
+  "language": "en"
+}, {
+  "uuid": "0d7e3892-b4ce-11e8-96f8-529269fb1459",
+  "text": "Previous channel",
+  "label": "television-program-minus",
+  "service": "television",
+  "language": "en"
+}, {
+  "uuid": "0d7e3d06-b4ce-11e8-96f8-529269fb1459",
+  "text": "Turn up the volume on television",
+  "label": "television-volume-up",
+  "service": "television",
+  "language": "en"
+}, {
+	"uuid": "0d7e3d06-b4ce-11e8-96f8-529269fb1459",
+	"text": "Turn down the volume on television",
+	"label": "television-volume-down",
+	"service": 0,
+	"language": "en"
+}, {
+  "uuid": "0d7e3e5a-b4ce-11e8-96f8-529269fb1459",
+  "text": "Mute the television",
+  "label": "television-mute",
+  "service": "television",
+  "language": "en"
+}, {
+  "uuid": "0d7e3f9a-b4ce-11e8-96f8-529269fb1459",
+  "text": "Unmute the television",
+  "label": "television-mute",
+  "service": "television",
+  "language": "en"
 }]

--- a/sentences/fr.json
+++ b/sentences/fr.json
@@ -1282,28 +1282,28 @@
   },
   {
     "uuid": "7d6ccc67-0b87-4816-8e84-c54fc9340b1b",
-    "text": "Augmente le son de la télévision",
+    "text": "Augmente le volume de la télévision",
     "label": "television-volume-up",
     "service": "television",
     "language": "fr"
   },
   {
     "uuid": "0d7e40d0-b4ce-11e8-96f8-529269fb1459",
-    "text": "Diminue le son de la télévision",
+    "text": "Diminue le volume de la télévision",
     "label": "television-volume-down",
     "service": "television",
     "language": "fr"
   },
   {
     "uuid": "d3d1093d-3da2-44e8-9ad0-82bb5b5f9abd",
-    "text": "Coupe le son de la télévision",
+    "text": "Coupe le volume de la télévision",
     "label": "television-mute",
     "service": "television",
     "language": "fr"
   },
   {
     "uuid": "d3d1093d-3da2-44e8-9ad0-82bb5b5f9abd",
-    "text": "Met le son de la télévision",
+    "text": "Met le volume de la télévision",
     "label": "television-mute",
     "service": "television",
     "language": "fr"

--- a/sentences/fr.json
+++ b/sentences/fr.json
@@ -1209,5 +1209,103 @@
     "label": "play-music",
     "service": 0,
     "language": "fr"
+  },
+  {
+    "uuid": "fc2e4620-50d7-452c-a97c-21f44aa46498",
+    "text": "Mets la chaine xx",
+    "label": "television-set-channel",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "35737f29-607e-4211-bd18-4fbdff1b230e",
+    "text": "Allume la télévision",
+    "label": "television-switch-state",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "e4733c22-daf6-402f-8405-f32e6973e260",
+    "text": "Éteint la télévision",
+    "label": "television-switch-state",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "1000e044-608c-4dc8-861c-97693f770d49",
+    "text": "Mets la télévision sur pause",
+    "label": "television-pause",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "36b5479d-e4d0-4e3d-b2e2-32cff25eb53b",
+    "text": "Arrete la video",
+    "label": "television-stop",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "f64ab472-cd40-4d18-8a82-fe4aba6b6854",
+    "text": "Mets la télévision sur play",
+    "label": "television-play",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "aeb59b94-23d0-435b-ba20-860ac1f177bb",
+    "text": "Rembobine la video",
+    "label": "television-rewind",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "eeddddba-eee0-48fd-bbe5-e5b8cbd9b647",
+    "text": "Avance la video",
+    "label": "television-fast-forward",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "0b58b170-23cb-47a0-a6d4-5ab34372ccf9",
+    "text": "Met la chaine suivante",
+    "label": "television-program-plus",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "71a7be63-0e57-4407-be2e-15988213449f",
+    "text": "Met la chaine précédente",
+    "label": "television-program-minus",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "7d6ccc67-0b87-4816-8e84-c54fc9340b1b",
+    "text": "Augmente le son de la télévision",
+    "label": "television-volume-up",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "0d7e40d0-b4ce-11e8-96f8-529269fb1459",
+    "text": "Diminue le son de la télévision",
+    "label": "television-volume-down",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "d3d1093d-3da2-44e8-9ad0-82bb5b5f9abd",
+    "text": "Coupe le son de la télévision",
+    "label": "television-mute",
+    "service": "television",
+    "language": "fr"
+  },
+  {
+    "uuid": "d3d1093d-3da2-44e8-9ad0-82bb5b5f9abd",
+    "text": "Met le son de la télévision",
+    "label": "television-mute",
+    "service": "television",
+    "language": "fr"
   }
 ]


### PR DESCRIPTION
Topic on Gladys website : 
https://community.gladysproject.com/t/integration-api-television-dans-gladys/3358

API definition : 

> gladys.television.pressKey()
> gladys.television.getSources()
> gladys.television.openSources()
> gladys.television.openMenu()
> gladys.television.rec() 
> gladys.television.play() 
> gladys.television.pause() 
> gladys.television.rewind() 
> gladys.television.fastForward() 
> gladys.television.switchState() 
> gladys.television.getState() 
> gladys.television.programPlus() 
> gladys.television.programMinus() 
> gladys.television.setChannel() 
> gladys.television.volumeDown() 
> gladys.television.volumeUp() 
> gladys.television.setMuted() 
> gladys.television.yellowButton() 
> gladys.television.greenButton() 
> gladys.television.redButton() 
> gladys.television.blueButton() 

Until 4 devicetypes can be used : 

- Power devicetype 
- Sound devicetype
- Channel devicetype
- Mute devicetype

New sentences & new answer can be used with this api : 

- Open Channel 3 on TV on living room
=> The channel was changed !

And new box was added by @piznel  
![unknown-4](https://user-images.githubusercontent.com/33568805/45600998-dec73480-ba05-11e8-8045-59cbe43adf79.png)
![unknown-5](https://user-images.githubusercontent.com/33568805/45601001-e555ac00-ba05-11e8-9a42-cd217f430e93.png)
